### PR TITLE
Fix captain.sh bootstrap installation

### DIFF
--- a/captain.sh
+++ b/captain.sh
@@ -51,6 +51,9 @@ else
                 ../build/kraken kraken.krak
                 popd
                 popd
+                pushd deprecated_compiler/build_kraken/kraken
+                sh kraken.sh
+                popd
                 cp deprecated_compiler/build_kraken/kraken/kraken ../${kraken}_bootstrap
                 popd
                 # Now make 


### PR DESCRIPTION
Trying to copy a file that didn't exist yet caused
the script to break when running it the first time.